### PR TITLE
styleguide: nav items for better readability

### DIFF
--- a/public/styleguide/css/styleguide.css
+++ b/public/styleguide/css/styleguide.css
@@ -115,6 +115,9 @@ html, body {
     .sg-header a:hover, .sg-header a:focus, .sg-header a.active {
       color: white;
       background: rgba(255, 255, 255, 0.05); }
+  .sg-header ol li ol li ol li a {
+    padding-left: 2em;
+    text-transform: none; }
 
 /* Navigation */
 .sg-header .sg-nav-toggle {
@@ -291,7 +294,7 @@ html, body {
 .sg-input {
   margin: -2px 0 0 0;
   padding: 0;
-  border: 1px solid #222;
+  border: 1px solid #222222;
   background-color: #222;
   color: gray;
   width: 35px;

--- a/public/styleguide/css/styleguide.scss
+++ b/public/styleguide/css/styleguide.scss
@@ -159,7 +159,7 @@ html, body {
 		padding: 0;
 		margin: 0;
 	}
-	
+
 	li {
 		list-style: none;
 		border-bottom: 1px solid $sg-tint;
@@ -179,6 +179,25 @@ html, body {
 			background: $sg-tint;
 		}
 	}
+
+	ol{
+    li{
+      ol{
+        li{
+          ol{
+            li{
+              //3rd level nav item
+							a{
+								padding-left: 2em;
+								text-transform: none;
+							}
+            }
+          }
+        }
+      }
+    }
+  }
+  
 }
 
 


### PR DESCRIPTION
Added padding to and removed text transform from 3rd level main nav items for better readability.
All nav items on all levels were left aligned and uppercased. I think now you can identify the 3rd level items much faster and better.

this is my first pull request ever in git(hub) so if i've done anything wrong, please tell me :)
