### PR TITLE
Added home page to pattern lab

### DIFF
--- a/public/styleguide/js/styleguide.js
+++ b/public/styleguide/js/styleguide.js
@@ -445,9 +445,22 @@
 	
 })(this);
 
+// reload the iframes initial state when clicking on home
+$('.sg-nav-home').on('click', function(e){
+	
+	document.getElementById("sg-viewport").contentWindow.location.assign(iFramePath);
+
+	//todo push state to maintain history.  not familiar with this yet.
+	
+	e.stopPropagation();
+
+	return false;
+
+});
+
 // update the iframe with the source from clicked element in pull down menu. also close the menu
 // having it outside fixes an auto-close bug i ran into
-$('.sg-nav a').not('.sg-acc-handle').on("click", function(e){
+$('.sg-nav a').not('.sg-acc-handle').not('.sg-nav-home').on("click", function(e){
 	
 	// update the iframe via the history api handler
 	urlHandler.pushPattern($(this).attr("data-patternpartial"));

--- a/source/_patternlab-files/partials/patternNav.mustache
+++ b/source/_patternlab-files/partials/patternNav.mustache
@@ -1,4 +1,5 @@
 <ol class="sg-nav">
+	<li><a href="?" class="sg-nav-home">Home</a></li>
 	{{# buckets }}
 		<li class="sg-nav-{{ bucketNameLC }}"><a class="sg-acc-handle">{{ bucketNameUC }}</a><ol class="sg-acc-panel">
 		{{# navItems }}


### PR DESCRIPTION
Enhancement to nav bar making it more obvious to users how to return to
the default state of patternlab, rather than relying on page reload or
history. When I first used Pattern Lab
and clicked on a pattern, I struggled with how to return.

This is not updating the history stack yet, I was hoping @dmolson could help
me learn more about that if this pull request is approved in the first place. cc @bradfrost

![image](https://f.cloud.github.com/assets/298435/1086027/eaea059c-15ed-11e3-9756-0fea6221da1f.png)
