### PR TITLE
linking via mustache variables fixed

### DIFF
--- a/builder/lib/builder.lib.php
+++ b/builder/lib/builder.lib.php
@@ -301,7 +301,7 @@ class Builder {
 			foreach($patterns as $pattern => $path) {
 				$patternName = $patternTypeName."-".$pattern;
 				$path = str_replace("/","-",$path);
-				$this->d->link->$patternName = "/patterns/".$path."/".$path.".html";
+				$this->d->link->$patternName = "../../patterns/".$path."/".$path.".html";
 			}
 			
 		}


### PR DESCRIPTION
hi there,

if you want to link different templates and use: 
{{ link.templates-templatename }}
it will be rendered to something like this:
/patterns/03-templates-10-subfolder-02-templatename/03-templates-10-subfolder-02-templatename.html
and this results in a 404.

so i put myself in sherlock mode and found this little buddy in builder.lip.php on line 304:
$this->d->link->$patternName = "/patterns/".$path."/".$path.".html";
a brief edit later
$this->d->link->$patternName = "../../patterns/".$path."/".$path.".html";
everything worked.
