### PR TITLE
Watcher class namespace fix

### DIFF
--- a/builder/lib/PatternLab/Watcher.php
+++ b/builder/lib/PatternLab/Watcher.php
@@ -41,7 +41,7 @@ class Watcher extends Builder {
 		
 		$c  = false;          // track that one loop through the pattern file listing has completed
 		$o  = new \stdClass(); // create an object to hold the properties
-		$cp = new \StdClass(); // create an object to hold a clone of $o
+		$cp = new \stdClass(); // create an object to hold a clone of $o
 		
 		$o->patterns = new \stdClass();
 		


### PR DESCRIPTION
Use of unqualified name `stdClass` in the `watcher` class caused `SplClassLoader` to look for `stdClass` in `PatternLab` (the current namespace), requiring `builder/lib/PatternLab/stdClass.php`, which doesn't exist and triggers a warning. 

```
PHP Warning:  require(~/patternlab-php/builder/lib/PatternLab/stdClass.php): failed to open stream: No such file or directory in ~/patternlab-php/builder/lib/SplClassLoader.php on line 133
PHP Stack trace:
PHP   1. {main}() ~/patternlab-php/builder/builder.php:0
PHP   2. PatternLab\Watcher->watch() ~/patternlab-php/builder/builder.php:83
PHP   3. SplClassLoader->loadClass() ~/patternlab-php/builder/builder.php:0
PHP Fatal error:  require(): Failed opening required '~/patternlab-php/builder/lib/PatternLab/stdClass.php' (include_path='.:/usr/local/php5/lib/php') in ~/patternlab-php/builder/lib/SplClassLoader.php on line 133
PHP Stack trace:
PHP   1. {main}() ~/patternlab-php/builder/builder.php:0
PHP   2. PatternLab\Watcher->watch() ~/patternlab-php/builder/builder.php:83
PHP   3. SplClassLoader->loadClass() ~/patternlab-php/builder/builder.php:0
```

I simply replaced the unqualified name with the fully qualified name, `\stdClass`, to reference the global class in the global namespace. No more warning.

I also changed the Pascal case of 'StdClass' to camel case on line 44 to match the other lines. Since classnames are not case sensitive, this is of little or no consequence. 
