### PR TITLE
fix for resize handle

### DIFF
--- a/core/styleguide/js/styleguide.js
+++ b/core/styleguide/js/styleguide.js
@@ -432,7 +432,7 @@
 		$('#sg-cover').mousemove(function(event) {
 			var viewportWidth;
 			
-			viewportWidth = (origClientX > event.clientX) ? origViewportWidth - (origClientX - event.clientX) : origViewportWidth + (event.clientX - origClientX);
+			viewportWidth = origViewportWidth + 2*(event.clientX - origClientX);
 			
 			if (viewportWidth > minViewportWidth) {
 				


### PR DESCRIPTION
when you resize the patternlab viewport via mouse, the resize handle moved slower than the mouse. 
I fixed it & also simplified the line
