### PR TITLE
Links with no href attribute shouldn't cause a 404

### DIFF
--- a/core/styleguide/js/postmessage.js
+++ b/core/styleguide/js/postmessage.js
@@ -32,7 +32,7 @@ if (self != top) {
 		aTags[i].onclick = function(e) {
 			e.preventDefault();
 			var href = this.getAttribute("href");
-			if (href.length && href !== "#") {
+			if (href && href !== "#") {
 				window.location.replace(href);
 			}
 		};


### PR DESCRIPTION
A 3rd party script I'm using  [Chosen](http://harvesthq.github.io/chosen/) generates an `a` element without a `href` attribute, which causes a 404 when clicked unless we check for `href.length` in the onclick handler. Seems like a generally good idea to include this check.
