### PR TITLE
Use offset().top to calculate .sg-acc-panel dynamic height

### DIFF
--- a/core/styleguide/js/styleguide.js
+++ b/core/styleguide/js/styleguide.js
@@ -1,5 +1,5 @@
 (function (w) {
-	
+
 	var sw = document.body.clientWidth, //Viewport Width
 		sh = $(document).height(), //Viewport Height
 		minViewportWidth = ishMinimum, //Minimum Size for Viewport
@@ -13,7 +13,7 @@
 		discoID = false,
 		discoMode = false,
 		hayMode = false;
-	
+
 	//Update dimensions on resize
 	$(w).resize(function() {
 		sw = document.body.clientWidth;
@@ -42,20 +42,24 @@
 		setAccordionHeight();
 	});
 
-	//Accordion Height 
+	//Accordion Height
 	function setAccordionHeight() {
-		var $activeAccordion = $('.sg-acc-panel.active').first(),
-			accordionHeight = $activeAccordion.height(),
-			availableHeight = sh-$headerHeight; //Screen height minus the height of the header
-		
-		$activeAccordion.height(availableHeight); //Set height of accordion to the available height
+		var $activeAccordion = $('.sg-acc-panel.active').first();
+
+		// Only get offset().top if we have an active accordion to avoid errors
+		if ($activeAccordion.length){
+			var $accordionOffset = Math.ceil($activeAccordion.offset().top), // Get offset().top of current accordion and round it up
+					availableHeight = sh - $accordionOffset; // Screen height minus offset().top of the current accordion
+
+			$activeAccordion.height(availableHeight); // Set height of accordion to the available height
+		}
 	}
 
 	$('.sg-nav-toggle').on("click", function(e){
 		e.preventDefault();
 		$('.sg-nav-container').toggleClass('active');
 	});
-	
+
 	// "View (containing clean, code, raw, etc options) Trigger
 	$('#sg-t-toggle').on("click", function(e){
 		e.preventDefault();
@@ -67,23 +71,23 @@
 		e.preventDefault();
 		$(this).parents('ul').toggleClass('active');
 	});
-	
+
 	//Phase View Events
 	$('.sg-size[data-size]').on("click", function(e){
 		e.preventDefault();
 		killDisco();
 		killHay();
-		
+
 		var val = $(this).attr('data-size');
-		
+
 		if (val.indexOf('px') > -1) {
 			$bodySize = 1;
 		}
-		
+
 		val = val.replace(/[^\d.-]/g,'');
 		sizeiframe(Math.floor(val*$bodySize));
 	});
-	
+
 	//Size View Events
 
 	// handle small button
@@ -92,59 +96,59 @@
 		killHay();
 		sizeiframe(getRandom(minViewportWidth,500));
 	}
-	
+
 	$('#sg-size-s').on("click", function(e){
 		e.preventDefault();
 		goSmall();
 	});
-	
+
 	jwerty.key('ctrl+shift+s', function(e) {
 		goSmall();
 		return false;
 	});
-	
+
 	// handle medium button
 	function goMedium() {
 		killDisco();
 		killHay();
 		sizeiframe(getRandom(500,800));
 	}
-	
+
 	$('#sg-size-m').on("click", function(e){
 		e.preventDefault();
 		goMedium();
 	});
-	
+
 	jwerty.key('ctrl+shift+m', function(e) {
 		goLarge();
 		return false;
 	});
-	
+
 	// handle large button
 	function goLarge() {
 		killDisco();
 		killHay();
 		sizeiframe(getRandom(800,1200));
 	}
-	
+
 	$('#sg-size-l').on("click", function(e){
 		e.preventDefault();
 		goLarge();
 	});
-	
+
 	jwerty.key('ctrl+shift+l', function(e) {
 		goLarge();
 		return false;
 	});
 
 	//Click Full Width Button
-	$('#sg-size-full').on("click", function(e){ //Resets 
+	$('#sg-size-full').on("click", function(e){ //Resets
 		e.preventDefault();
 		killDisco();
 		killHay();
 		sizeiframe(sw);
 	});
-	
+
 	//Click Random Size Button
 	$('#sg-size-random').on("click", function(e){
 		e.preventDefault();
@@ -152,7 +156,7 @@
 		killHay();
 		sizeiframe(getRandom(minViewportWidth,sw));
 	});
-	
+
 	//Click for Disco Mode, which resizes the viewport randomly
 	$('#sg-size-disco').on("click", function(e){
 		e.preventDefault();
@@ -170,18 +174,18 @@
 	function disco() {
 		sizeiframe(getRandom(minViewportWidth,sw));
 	}
-	
+
 	function killDisco() {
 		discoMode = false;
 		clearInterval(discoID);
 		discoID = false;
 	}
-	
+
 	function startDisco() {
 		discoMode = true;
 		discoID = setInterval(disco, 800);
 	}
-	
+
 	jwerty.key('ctrl+shift+d', function(e) {
 		if (!discoMode) {
 			startDisco();
@@ -210,21 +214,21 @@
 		$('#sg-gen-container').removeClass('hay-mode');
 		sizeiframe(Math.floor(currentWidth));
 	}
-	
+
 	// start Hay! mode
 	function startHay() {
 		hayMode = true;
 		$('#sg-gen-container').removeClass("vp-animate").width(minViewportWidth+viewportResizeHandleWidth);
 		$sgViewport.removeClass("vp-animate").width(minViewportWidth);
-		
+
 		var timeoutID = window.setTimeout(function(){
 			$('#sg-gen-container').addClass('hay-mode').width(maxViewportWidth+viewportResizeHandleWidth);
 			$sgViewport.addClass('hay-mode').width(maxViewportWidth);
-			
+
 			setInterval(function(){ var vpSize = $sgViewport.width(); updateSizeReading(vpSize); },100);
 		}, 200);
 	}
-	
+
 	// start hay from a keyboard shortcut
 	jwerty.key('ctrl+shift+h', function(e) {
 		if (!hayMode) {
@@ -276,20 +280,20 @@
 		var val = parseFloat($(this).val());
 		updateSizeReading(val,'em','updatePxInput');
 	});
-	
+
 	// set 0 to 320px as a default
 	jwerty.key('ctrl+shift+0', function(e) {
 		e.preventDefault();
 		sizeiframe(320,true);
 		return false;
 	});
-	
+
 	// handle the MQ click
 	var mqs = [];
 	$('#sg-mq a').each(function(i) {
-		
+
 		mqs.push($(this).html());
-		
+
 		// bind the click
 		$(this).on("click", function(i,k) {
 			return function(e) {
@@ -301,7 +305,7 @@
 				sizeiframe(width,true);
 			}
 		}(i,this));
-		
+
 		// bind the keyboard shortcut. can't use cmd on a mac because 3 & 4 are for screenshots
 		jwerty.key('ctrl+shift+'+(i+1), function (k) {
 			return function(e) {
@@ -313,15 +317,15 @@
 				return false;
 			}
 		}(this));
-		
+
 	});
-	
+
 	//Resize the viewport
 	//'size' is the target size of the viewport
 	//'animate' is a boolean for switching the CSS animation on or off. 'animate' is true by default, but can be set to false for things like nudging and dragging
 	function sizeiframe(size,animate) {
 		var theSize;
-		
+
 		if(size>maxViewportWidth) { //If the entered size is larger than the max allowed viewport size, cap value at max vp size
 			theSize = maxViewportWidth;
 		} else if(size<minViewportWidth) { //If the entered size is less than the minimum allowed viewport size, cap value at min vp size
@@ -329,31 +333,31 @@
 		} else {
 			theSize = size;
 		}
-		
+
 		//Conditionally remove CSS animation class from viewport
 		if(animate===false) {
 			$('#sg-gen-container,#sg-viewport').removeClass("vp-animate"); //If aninate is set to false, remove animate class from viewport
 		} else {
 			$('#sg-gen-container,#sg-viewport').addClass("vp-animate");
 		}
-		
+
 		$('#sg-gen-container').width(theSize+viewportResizeHandleWidth); //Resize viewport wrapper to desired size + size of drag resize handler
 		$sgViewport.width(theSize); //Resize viewport to desired size
-		
+
 		var targetOrigin = (window.location.protocol === "file:") ? "*" : window.location.protocol+"//"+window.location.host;
 		var obj = JSON.stringify({ "resize": "true" });
 		document.getElementById('sg-viewport').contentWindow.postMessage(obj,targetOrigin);
-		
+
 		updateSizeReading(theSize); //Update values in toolbar
 		saveSize(theSize); //Save current viewport to cookie
 	}
-	
+
 	$("#sg-gen-container").on('transitionend webkitTransitionEnd', function(e){
 		var targetOrigin = (window.location.protocol === "file:") ? "*" : window.location.protocol+"//"+window.location.host;
 		var obj = JSON.stringify({ "resize": "true" });
 		document.getElementById('sg-viewport').contentWindow.postMessage(obj,targetOrigin);
 	});
-	
+
 	function saveSize(size) {
 		if (!DataSaver.findValue('vpWidth')) {
 			DataSaver.addValue("vpWidth",size);
@@ -361,8 +365,8 @@
 			DataSaver.updateValue("vpWidth",size);
 		}
 	}
-	
-	
+
+
 	//Update Pixel and Em inputs
 	//'size' is the input number
 	//'unit' is the type of unit: either px or em. Default is px. Accepted values are 'px' and 'em'
@@ -377,7 +381,7 @@
 			pxSize = size;
 			emSize = size/$bodySize;
 		}
-		
+
 		if (target === 'updatePxInput') {
 			$sizePx.val(pxSize);
 		} else if (target === 'updateEmInput') {
@@ -387,17 +391,17 @@
 			$sizePx.val(pxSize);
 		}
 	}
-	
+
 	/* Returns a random number between min and max */
 	function getRandom (min, max) {
 		return Math.floor(Math.random() * (max - min) + min);
 	}
-	
+
 	//Update The viewport size
 	function updateViewportWidth(size) {
 		$("#sg-viewport").width(size);
 		$("#sg-gen-container").width(size*1 + 14);
-		
+
 		updateSizeReading(size);
 	}
 
@@ -409,10 +413,10 @@
 
 		alert('workit');
 	} else {
-		
+
 	}
 	*/
-	
+
 	$('#sg-gen-container').on('touchstart', function(event){});
 
 	// handles widening the "viewport"
@@ -420,34 +424,34 @@
 	//   2. make a hidden div visible so that it can track mouse movements and make sure the pointer doesn't get lost in the iframe
 	//   3. on "mousemove" calculate the math, save the results to a cookie, and update the viewport
 	$('#sg-rightpull').mousedown(function(event) {
-		
+
 		// capture default data
 		var origClientX = event.clientX;
 		var origViewportWidth = $sgViewport.width();
-		
+
 		// show the cover
 		$("#sg-cover").css("display","block");
-		
+
 		// add the mouse move event and capture data. also update the viewport width
 		$('#sg-cover').mousemove(function(event) {
 			var viewportWidth;
-			
+
 			viewportWidth = origViewportWidth + 2*(event.clientX - origClientX);
-			
+
 			if (viewportWidth > minViewportWidth) {
-				
+
 				if (!DataSaver.findValue('vpWidth')) {
 					DataSaver.addValue("vpWidth",viewportWidth);
 				} else {
 					DataSaver.updateValue("vpWidth",viewportWidth);
 				}
-				
+
 				sizeiframe(viewportWidth,false);
 			}
 		});
-		
+
 		return false;
-		
+
 	});
 
 	// on "mouseup" we unbind the "mousemove" event and hide the cover again
@@ -460,7 +464,7 @@
 	// capture the viewport width that was loaded and modify it so it fits with the pull bar
 	var origViewportWidth = $("#sg-viewport").width();
 	$("#sg-gen-container").width(origViewportWidth);
-	
+
 	var testWidth = screen.width;
 	if (window.orientation !== undefined) {
 		testWidth = (window.orientation == 0) ? screen.width : screen.height;
@@ -471,10 +475,10 @@
 		$("#sg-viewport").width(origViewportWidth - 14);
 	}
 	updateSizeReading($("#sg-viewport").width());
-	
+
 	// get the request vars
 	var oGetVars = urlHandler.getRequestVars();
-	
+
 	// pre-load the viewport width
 	var vpWidth = 0;
 	var trackViewportWidth = true; // can toggle this feature on & off
@@ -491,7 +495,7 @@
 	} else if (trackViewportWidth && (vpWidth = DataSaver.findValue("vpWidth"))) {
 		updateViewportWidth(vpWidth);
 	}
-	
+
 	// load the iframe source
 	var patternName = "all";
 	var patternPath = "";
@@ -501,16 +505,16 @@
 		patternPath = urlHandler.getFileName(patternName);
 		iFramePath  = (patternPath !== "") ? window.location.protocol+"//"+window.location.host+window.location.pathname.replace("index.html","")+patternPath+"?"+Date.now() : iFramePath;
 	}
-	
+
 	if (patternName !== "all") {
 		document.getElementById("title").innerHTML = "Pattern Lab - "+patternName;
 		history.replaceState({ "pattern": patternName }, null, null);
 	}
-	
+
 	if (document.getElementById("sg-raw") != undefined) {
 		document.getElementById("sg-raw").setAttribute("href",urlHandler.getFileName(patternName));
 	}
-	
+
 	urlHandler.skipBack = true;
 	document.getElementById("sg-viewport").contentWindow.location.replace(iFramePath);
 
@@ -534,7 +538,7 @@
 	$('#sg-vp-wrap').click(function() {
 		closePanels();
 	});
-	
+
 	// Listen for resize changes
 	if (window.orientation !== undefined) {
 		var origOrientation = window.orientation;
@@ -546,41 +550,41 @@
 				origOrientation = window.orientation;
 			}
 		}, false);
-		
+
 	}
-	
+
 	// watch the iframe source so that it can be sent back to everyone else.
 	// based on the great MDN docs at https://developer.mozilla.org/en-US/docs/Web/API/window.postMessage
 	function receiveIframeMessage(event) {
-		
+
 		var data = (typeof event.data !== "string") ? event.data : JSON.parse(event.data);
-		
+
 		// does the origin sending the message match the current host? if not dev/null the request
 		if ((window.location.protocol !== "file:") && (event.origin !== window.location.protocol+"//"+window.location.host)) {
 			return;
 		}
-		
+
 		if (data.bodyclick !== undefined) {
-			
+
 			closePanels();
-			
+
 		} else if (data.patternpartial !== undefined) {
-			
+
 			if (!urlHandler.skipBack) {
-				
+
 				if ((history.state === undefined) || (history.state === null) || (history.state.pattern !== data.patternpartial)) {
 					urlHandler.pushPattern(data.patternpartial, data.path);
 				}
-				
+
 				if (wsnConnected) {
 					var iFramePath = urlHandler.getFileName(data.patternpartial);
 					wsn.send( '{"url": "'+iFramePath+'", "patternpartial": "'+event.data.patternpartial+'" }' );
 				}
 			}
-			
+
 			// reset the defaults
 			urlHandler.skipBack = false;
-			
+
 		} else if (data.keyPress !== undefined) {
 			if (data.keyPress == 'ctrl+shift+s') {
 				goSmall();
@@ -613,7 +617,7 @@
 		}
 	}
 	window.addEventListener("message", receiveIframeMessage, false);
-	
+
 	if (qrCodeGeneratorOn) {
 		$('.sg-tools').click(function() {
 			if ((qrCodeGenerator.lastGenerated == "") || (qrCodeGenerator.lastGenerated != window.location.search)) {
@@ -622,5 +626,5 @@
 			}
 		});
 	}
-	
+
 })(this);


### PR DESCRIPTION
Currently we're using [viewport height minus header height](https://github.com/pattern-lab/patternlab-php/blob/master/core/styleguide/js/styleguide.js#L49), but on small screens the menu items are stacked underneath the header, resulting in inaccurate height calculations and viewport overflow issues as reported in #145.

If we use the currently active accordion's `offset().top` value instead of header height, the height calculation is much more accurate.

Since `.offset()` returns decimals, I set it to round up to the next pixel. 

I tested on my iPhone 4s / iOS 7 / Safari, and it seems to resolve the issue.

Hopefully dev is the right branch to submit PRs against. I'm happy to resubmit if you tell me otherwise or if you find any issues.
