### PR TITLE
Fix typo

### DIFF
--- a/core/source/_patterns/00-atoms/02-text/03-inline-elements.mustache
+++ b/core/source/_patterns/00-atoms/02-text/03-inline-elements.mustache
@@ -37,5 +37,5 @@
 
 	<p><samp>This is sample output from a computer program</samp></p>
 
-	<p>The <var>variarble element</var>, such as <var>x</var> = <var>y</var></p>
+	<p>The <var>variable element</var>, such as <var>x</var> = <var>y</var></p>
 </div><!--end .text-->

--- a/core/styleguide/html/styleguide.html
+++ b/core/styleguide/html/styleguide.html
@@ -343,7 +343,7 @@
 
 	<p><samp>This is sample output from a computer program</samp></p>
 
-	<p>The <var>variarble element</var>, such as <var>x</var> = <var>y</var></p>
+	<p>The <var>variable element</var>, such as <var>x</var> = <var>y</var></p>
 </div><!--end .text-->
 							<div class="sg-code" style="display: none">
 								<h3 class="sg-code-head">HTML</h3>
@@ -388,7 +388,7 @@
 
 	&lt;p&gt;&lt;samp&gt;This is sample output from a computer program&lt;/samp&gt;&lt;/p&gt;
 
-	&lt;p&gt;The &lt;var&gt;variarble element&lt;/var&gt;, such as &lt;var&gt;x&lt;/var&gt; = &lt;var&gt;y&lt;/var&gt;&lt;/p&gt;
+	&lt;p&gt;The &lt;var&gt;variable element&lt;/var&gt;, such as &lt;var&gt;x&lt;/var&gt; = &lt;var&gt;y&lt;/var&gt;&lt;/p&gt;
 &lt;/div&gt;&lt;!--end .text--&gt;
 									</code>
 								</pre>


### PR DESCRIPTION
Fixed a tiny typo in “variable”.
