### PR TITLE
Fixed the id collision in demo forms atoms

### DIFF
--- a/core/source/_patterns/00-atoms/05-forms/00-text-fields.mustache
+++ b/core/source/_patterns/00-atoms/05-forms/00-text-fields.mustache
@@ -20,8 +20,8 @@
         <input id="search" type="search" placeholder="Enter Search Term">
     </div>
     <div class="field-container">
-        <label for="text">Number Input <abbr title="Required">*</abbr></label>
-        <input id="text" type="number" placeholder="Enter a Number" pattern="[0-9]*">
+        <label for="number">Number Input <abbr title="Required">*</abbr></label>
+        <input id="number" type="number" placeholder="Enter a Number" pattern="[0-9]*">
     </div>
     <div class="field-container">
         <label for="textarea">Textarea</label>


### PR DESCRIPTION
`<input>` for number inputs had the same `id` as the `<input>` for text inputs.
