### PR TITLE
Using styleGuideExcludes in config.ini produces an "Invalid argument supplied" warning

### DIFF
--- a/core/lib/PatternLab/Builder.php
+++ b/core/lib/PatternLab/Builder.php
@@ -953,7 +953,7 @@ class Builder {
 					$arrayReset = false;
 				}
 				
-			} else {
+			} elseif (isset($patternTypeValues["patternItems"])) {
 				
 				foreach ($patternTypeValues["patternItems"] as $patternSubtypeKey => $patternSubtypeItem) {
 					// set the pattern state


### PR DESCRIPTION
#246 Using styleGuideExcludes in config.ini produces an "Invalid argument supplied" warning

Adding condition to check if patternItems is set before attempting to perform a foreach which throws an error when its not during build.