### PR TITLE
Fix #181: `.sg-code-contains code` color is the same as background-color

### DIFF
--- a/core/styleguide/css/styleguide.css
+++ b/core/styleguide/css/styleguide.css
@@ -583,7 +583,6 @@ span.sg-pattern-state:before {
   .sg-code-contains code {
     padding: 0.2em;
     background: rgba(0, 0, 0, 0.3);
-    color: #999999;
     position: relative;
     top: -2px; }
 

--- a/core/styleguide/css/styleguide.scss
+++ b/core/styleguide/css/styleguide.scss
@@ -816,7 +816,6 @@ span.sg-pattern-state:before {
 	code {
 		padding: 0.2em;
 		background: $sg-tone-2;
-		color: $sg-quinary;
 		position: relative;
 		top: -2px;
 	}


### PR DESCRIPTION
I removed color and had it inherit from styles set earlier in the file
