### PR TITLE
Added config for custom path to 00-meta folder

### DIFF
--- a/core/config/config.ini.default
+++ b/core/config/config.ini.default
@@ -41,3 +41,7 @@ styleGuideExcludes = ""
 
 // should the cache buster be on, set to false to set the cacheBuster value to 0
 cacheBusterOn = "true"
+
+// location of 00-meta folder, i.e. head and foot. Leave blank for default
+// needs trailing slash
+metaPath = ""

--- a/core/lib/PatternLab/Builder.php
+++ b/core/lib/PatternLab/Builder.php
@@ -972,8 +972,12 @@ class Builder {
 		$extraFoot          = file_get_contents(__DIR__."/../../templates/pattern-header-footer/footer-pattern.html");
 		
 		// gather the user-defined header and footer information
-		$patternHeadPath    = __DIR__.$this->sp."00-atoms/00-meta/_00-head.mustache";
-		$patternFootPath    = __DIR__.$this->sp."00-atoms/00-meta/_01-foot.mustache";
+		$metaFolderPath = "00-atoms/00-meta/";
+		if(!empty($this->metaPath)) {
+			$metaFolderPath = ($this->metaPath == "" ? "00-atoms/00-meta/" : $this->metaPath);
+		}
+		$patternHeadPath    = __DIR__.$this->sp.$metaFolderPath."_00-head.mustache";
+		$patternFootPath    = __DIR__.$this->sp.$metaFolderPath."_01-foot.mustache";
 		$patternHead        = (file_exists($patternHeadPath)) ? file_get_contents($patternHeadPath) : "";
 		$patternFoot        = (file_exists($patternFootPath)) ? file_get_contents($patternFootPath) : "";
 		


### PR DESCRIPTION
Hi Dave and Brad.
Love pattern lab. 
Not sure if this is useful to other folks, but I added a config.ini option to specify location of 00-meta folder. 
By default, it is `00-atoms/00-meta/`
Usage: 
```
metaPath = "01-atoms/00-meta/"
```

Looks like new version in `dev` branch is quite different. Look forward to update! Thanks for your open sourcing this awesome tool!
Daigo