### PR TITLE
Making source and public folders a setting in config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+## Difference with the main branch 
+In the original [patternlab-php](https://github.com/pattern-lab/patternlab-php) (as for release 0.7.12) `/source` and `/public` directories were hard-coded in different places (php, json etc). So the difference here is that the source and the output paths were made configurable via `config.ini`. By default both paths are the same as in the original version, but you can change them by tweaking `core/config/config.ini.default` before starting the generator for the first time.
+
+NOTES:
+* paths should be related to the PatterLab root folder (where `/config`, `/core` and `/extras` folders are placed).
+* if a path doesn't exists, all levels will be fully created during the first run
+* since paths are now configurable and created automatically, the original `/source` and `/public` folders were removed from the project root
+
+So, for example, these are now quite possible settings in `config.ini.default` for paths:
+`sourceDir = "some/long/path/to/source"`
+`publicDir = "../../../path/could/go/even/outside/patterlab/directory"` (yes, both directories could be even outside the PatternLab root folder)
+
+P.S. Yes, I noticed that in the original `dev` branch some major changes have been done to make these paths configurable, but the last commits were made about a year ago and this work doesn't seemed to be finished. That's why I decided to implement this functionality in a pretty simple way, without huge refactoring of the code. Hope this will allow the community to use PatternLab in a much more flexible way. And of course many thanks to Dave Olsen and all other contributors for this wonderful tool :))
+
 ## About Pattern Lab
 - [Pattern Lab Website](http://patternlab.io/)
 - [About Pattern Lab](http://patternlab.io/about.html)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ NOTES:
 * since paths are now configurable and created automatically, the original `/source` and `/public` folders were removed from the project root
 
 So, for example, these are now quite possible settings in `config.ini.default` for paths:
+
 `sourceDir = "some/long/path/to/source"`
+
 `publicDir = "../../../path/could/go/even/outside/patterlab/directory"` (yes, both directories could be even outside the PatternLab root folder)
 
 P.S. Yes, I noticed that in the original `dev` branch some major changes have been done to make these paths configurable, but the last commits were made about a year ago and this work doesn't seemed to be finished. That's why I decided to implement this functionality in a pretty simple way, without huge refactoring of the code. Hope this will allow the community to use PatternLab in a much more flexible way. And of course many thanks to Dave Olsen and all other contributors for this wonderful tool :))

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ NOTES:
 * paths should be related to the PatterLab root folder (where `/config`, `/core` and `/extras` folders are placed).
 * if a path doesn't exists, all levels will be fully created during the first run
 * since paths are now configurable and created automatically, the original `/source` and `/public` folders were removed from the project root
+* both directories could be even outside the PatternLab root folder
 
-So, for example, these are now quite possible settings in `config.ini.default` for paths:
+For example, these are now quite possible settings in `config.ini.default` for paths:
 
 `sourceDir = "some/long/path/to/source"`
 
-`publicDir = "../../../path/could/go/even/outside/patterlab/directory"` (yes, both directories could be even outside the PatternLab root folder)
+`publicDir = "../../../path/could/go/even/outside/patterlab/directory"`
 
 P.S. Yes, I noticed that in the original `dev` branch some major changes have been done to make these paths configurable, but the last commits were made about a year ago and this work doesn't seemed to be finished. That's why I decided to implement this functionality in a pretty simple way, without huge refactoring of the code. Hope this will allow the community to use PatternLab in a much more flexible way. And of course many thanks to Dave Olsen and all other contributors for this wonderful tool :))
 

--- a/core/autoReloadServer.php
+++ b/core/autoReloadServer.php
@@ -33,7 +33,7 @@ $newlines = (isset($args["s"])) ? true : false;
 $server   = new \Wrench\Server('ws://0.0.0.0:'.$port.'/', array());
 
 // register the application
-$server->registerApplication('autoreload', new \Wrench\Application\AutoReloadApplication($newlines));
+$server->registerApplication('autoreload', new \Wrench\Application\AutoReloadApplication($newlines, $config));
 
 if (!isset($args["s"])) {
 	print "\n";

--- a/core/config/config.ini.default
+++ b/core/config/config.ini.default
@@ -41,3 +41,9 @@ styleGuideExcludes = ""
 
 // should the cache buster be on, set to false to set the cacheBuster value to 0
 cacheBusterOn = "true"
+
+// the public directory
+publicDir = "public"
+
+// the source directory
+sourceDir = "source"

--- a/core/lib/PatternLab/Builder.php
+++ b/core/lib/PatternLab/Builder.php
@@ -61,12 +61,13 @@ class Builder {
 			}
 			
 		}
-		
+		print "\nSource dir: ".$this->sourceDir;
+		print "\nPublic dir: ".$this->publicDir."\n";
 		// set-up the source & public dirs
-		$this->sp = "/../../../source/_patterns".DIRECTORY_SEPARATOR;
-		$this->pp = "/../../../public/patterns".DIRECTORY_SEPARATOR;
-		$this->sd = __DIR__."/../../../source";
-		$this->pd = __DIR__."/../../../public";
+		$this->sp = "/../../../".$this->sourceDir."/_patterns".DIRECTORY_SEPARATOR;
+		$this->pp = "/../../../".$this->publicDir."/patterns".DIRECTORY_SEPARATOR;
+		$this->sd = __DIR__."/../../../".$this->sourceDir;
+		$this->pd = __DIR__."/../../../".$this->publicDir;
 		
 		// provide the default for enable CSS. performance hog so it should be run infrequently
 		$this->enableCSS    = false;

--- a/core/lib/PatternLab/Builder.php
+++ b/core/lib/PatternLab/Builder.php
@@ -61,8 +61,6 @@ class Builder {
 			}
 			
 		}
-		print "\nSource dir: ".$this->sourceDir;
-		print "\nPublic dir: ".$this->publicDir."\n";
 		// set-up the source & public dirs
 		$this->sp = "/../../../".$this->sourceDir."/_patterns".DIRECTORY_SEPARATOR;
 		$this->pp = "/../../../".$this->publicDir."/patterns".DIRECTORY_SEPARATOR;

--- a/core/lib/PatternLab/Configurer.php
+++ b/core/lib/PatternLab/Configurer.php
@@ -66,7 +66,7 @@ class Configurer {
 			print "upgrading your version of pattern lab...\n";
 			print "checking for migrations...\n";
 			$m = new Migrator;
-			$m->migrate(true);
+			$m->migrate(true, $config);
 			if ($migrate) {
 				if (!@copy($this->plConfigPath, $this->userConfigPath)) {
 					print "Please make sure that Pattern Lab can write a new config to config/.\n";

--- a/core/lib/PatternLab/Configurer.php
+++ b/core/lib/PatternLab/Configurer.php
@@ -51,7 +51,9 @@ class Configurer {
 		$defaultConfig = $config;
 		
 		// check to see if the user config exists, if not create it
-		print "configuring pattern lab...\n";
+		print "configuring pattern lab...";
+		print "\nsource dir: ".$config['sourceDir'];
+		print "\npublic dir: ".$config['publicDir']."\n\n";
 		if (!file_exists($this->userConfigPath)) {
 			$migrate = true;
 		} else {

--- a/core/lib/PatternLab/Migrator.php
+++ b/core/lib/PatternLab/Migrator.php
@@ -25,7 +25,7 @@ class Migrator {
 	* Read through the migrations and move files as needed
 	* @param  {Boolean}      is this a different version
 	*/
-	public function migrate($diffVersion = false) {
+	public function migrate($diffVersion = false, $config) {
 		
 		$migrations      = new \DirectoryIterator(__DIR__."/../../migrations/");
 		$migrationsValid = array();
@@ -38,15 +38,24 @@ class Migrator {
 		}
 		
 		asort($migrationsValid);
-		
+
 		foreach ($migrationsValid as $filename) {
 			
 			$basePath        = __DIR__."/../../../";
 			$migrationData   = json_decode(file_get_contents(__DIR__."/../../migrations/".$filename));
 			$checkType       = $migrationData->checkType;
 			$sourcePath      = ($checkType == "fileExists") ? $basePath.$migrationData->sourcePath : $basePath.$migrationData->sourcePath.DIRECTORY_SEPARATOR;
-			$destinationPath = ($checkType == "fileExists") ? $basePath.$migrationData->destinationPath : $basePath.$migrationData->destinationPath.DIRECTORY_SEPARATOR;
-			
+
+			$destinationPath = preg_replace_callback( 
+				// replace in migration's paths {valueName} with valueName setting from config.ini
+				'/(\{.*\})/', 
+				function($matches)use($config) {
+					return  $config[ trim($matches[0], "{}") ];
+				},
+				$basePath.$migrationData->destinationPath
+			);
+			$destinationPath .= ($checkType == "fileExists") ? '' : DIRECTORY_SEPARATOR;
+
 			if ($checkType == "dirEmpty") {
 				
 				$emptyDir = true;

--- a/core/lib/PatternLab/Migrator.php
+++ b/core/lib/PatternLab/Migrator.php
@@ -73,7 +73,7 @@ class Migrator {
 			} else if ($checkType == "dirExists") {
 				
 				if (!is_dir($destinationPath)) {
-					mkdir($destinationPath);
+					mkdir($destinationPath, 0777, true);
 				}
 				
 			} else if ($checkType == "fileExists") {

--- a/core/lib/Wrench/Application/AutoReloadApplication.php
+++ b/core/lib/Wrench/Application/AutoReloadApplication.php
@@ -31,8 +31,8 @@ class AutoReloadApplication extends Application {
 		
 		$this->newlines = $newlines;
 		
-		if (file_exists(__DIR__."/../../../../public/latest-change.txt")) {
-			$this->savedTimestamp = file_get_contents(__DIR__."/../../../../public/latest-change.txt");
+		if (file_exists(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt")) {
+			$this->savedTimestamp = file_get_contents(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt");
 		} else {
 			$this->savedTimestamp = time();
 		}
@@ -67,8 +67,8 @@ class AutoReloadApplication extends Application {
 	*/
 	public function onUpdate() {
 		
-		if (file_exists(__DIR__."/../../../../public/latest-change.txt")) {
-			$readTimestamp = file_get_contents(__DIR__."/../../../../public/latest-change.txt");
+		if (file_exists(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt")) {
+			$readTimestamp = file_get_contents(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt");
 			if ($readTimestamp != $this->savedTimestamp) {
 				print "pattern lab updated. alerting connected browsers...\n";
 				foreach ($this->clients as $sendto) {

--- a/core/lib/Wrench/Application/AutoReloadApplication.php
+++ b/core/lib/Wrench/Application/AutoReloadApplication.php
@@ -23,16 +23,18 @@ class AutoReloadApplication extends Application {
 	protected $clients          = array();
 	protected $savedTimestamp   = null;
 	protected $c                = false;
+	protected $filename         = "";
 	
 	/**
 	* Set the saved timestamp. If the latest-change file doesn't exist simply use the current time as the saved time
 	*/
-	public function __construct($newlines) {
+	public function __construct($newlines, $config) {
 		
 		$this->newlines = $newlines;
-		
-		if (file_exists(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt")) {
-			$this->savedTimestamp = file_get_contents(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt");
+		$this->filename = __DIR__."/../../../../".$config['publicDir']."/latest-change.txt";
+
+		if (file_exists($this->filename)) {
+			$this->savedTimestamp = file_get_contents($this->filename);
 		} else {
 			$this->savedTimestamp = time();
 		}
@@ -67,8 +69,8 @@ class AutoReloadApplication extends Application {
 	*/
 	public function onUpdate() {
 		
-		if (file_exists(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt")) {
-			$readTimestamp = file_get_contents(__DIR__."/../../../../".$config['publicDir']."/latest-change.txt");
+		if (file_exists($this->filename)) {
+			$readTimestamp = file_get_contents($this->filename);
 			if ($readTimestamp != $this->savedTimestamp) {
 				print "pattern lab updated. alerting connected browsers...\n";
 				foreach ($this->clients as $sendto) {

--- a/core/migrations/000-check-public-exists.json
+++ b/core/migrations/000-check-public-exists.json
@@ -1,0 +1,5 @@
+{
+	"sourcePath": "",
+	"destinationPath": "{publicDir}",
+	"checkType": "dirExists"
+}

--- a/core/migrations/000-check-source-exists.json
+++ b/core/migrations/000-check-source-exists.json
@@ -1,0 +1,5 @@
+{
+	"sourcePath": "",
+	"destinationPath": "{sourceDir}",
+	"checkType": "dirExists"
+}

--- a/core/migrations/001-move-source.json
+++ b/core/migrations/001-move-source.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "core/source",
-	"destinationPath": "source",
+	"destinationPath": "{sourceDir}",
 	"checkType": "dirEmpty"
 }

--- a/core/migrations/002-check-public-styleguide-exists.json
+++ b/core/migrations/002-check-public-styleguide-exists.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "",
-	"destinationPath": "public/styleguide",
+	"destinationPath": "{publicDir}/styleguide",
 	"checkType": "dirExists"
 }

--- a/core/migrations/003-move-styleguide.json
+++ b/core/migrations/003-move-styleguide.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "core/styleguide",
-	"destinationPath": "public/styleguide",
+	"destinationPath": "{publicDir}/styleguide",
 	"checkType": "versionDiffDir"
 }

--- a/core/migrations/004-check-meta-exists.json
+++ b/core/migrations/004-check-meta-exists.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "",
-	"destinationPath": "source/_patterns/00-atoms/00-meta",
+	"destinationPath": "{sourceDir}/_patterns/00-atoms/00-meta",
 	"checkType": "dirExists"
 }

--- a/core/migrations/005-move-pattern-header-footer.json
+++ b/core/migrations/005-move-pattern-header-footer.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "core/source/_patterns/00-atoms/00-meta",
-	"destinationPath": "source/_patterns/00-atoms/00-meta",
+	"destinationPath": "{sourceDir}/_patterns/00-atoms/00-meta",
 	"checkType": "dirEmpty"
 }

--- a/core/migrations/006-check-public-data-exists.json
+++ b/core/migrations/006-check-public-data-exists.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "",
-	"destinationPath": "public/data",
+	"destinationPath": "{publicDir}/data",
 	"checkType": "dirExists"
 }

--- a/core/migrations/007-check-public-patterns-exists.json
+++ b/core/migrations/007-check-public-patterns-exists.json
@@ -1,5 +1,5 @@
 {
 	"sourcePath": "",
-	"destinationPath": "public/patterns",
+	"destinationPath": "{publicDir}/patterns",
 	"checkType": "dirExists"
 }

--- a/public/README
+++ b/public/README
@@ -1,3 +1,0 @@
-To populate this directory you need to generate the PHP version of Pattern Lab for the first time.
-To do so either run "php core/builder.php -g" at the command line or, if you're on a Mac, double-click
-on "core/scripts/generateSite.command".

--- a/source/README
+++ b/source/README
@@ -1,1 +1,0 @@
-After you generate Pattern Lab for the first time your source files will be placed here.


### PR DESCRIPTION
In the original [patternlab-php](https://github.com/pattern-lab/patternlab-php) (as for release 0.7.12) `/source` and `/public` directories were hard-coded in different places (php, json etc). So the difference here is that the source and the output paths were made configurable via `config.ini`. By default both paths are the same as in the original version, but you can change them by tweaking `core/config/config.ini.default` before starting the generator for the first time.

NOTES:
- paths should be related to the PatterLab root folder (where `/config`, `/core` and `/extras` folders are placed).
- if a path doesn't exists, all levels will be fully created during the first run
- since paths are now configurable and created automatically, the original `/source` and `/public` folders were removed from the project root
- both directories could be even outside the PatternLab root folder

For example, these are now quite possible settings in `config.ini.default` for paths:

`sourceDir = "some/long/path/to/source"`

`publicDir = "../../../path/could/go/even/outside/patterlab/directory"`

P.S. Yes, I noticed that in the original `dev` branch some major changes have been done to make these paths configurable, but the last commits were made about a year ago and this work doesn't seemed to be finished. That's why I decided to implement this functionality in a pretty simple way, without huge refactoring of the code. Hope this will allow the community to use PatternLab in a much more flexible way. And of course many thanks to Dave Olsen and all other contributors for this wonderful tool :))
