### PR TITLE
add raw URL option for QR generation

### DIFF
--- a/core/config/config.ini.default
+++ b/core/config/config.ini.default
@@ -19,6 +19,8 @@ pageFollowPort = "8003"
 
 // whether the qr code generator should be loaded automatically in the nav
 qrCodeGeneratorOn = "false"
+// use the raw pattern URL in the QR code
+qrCodeGeneratorRaw = "true"
 
 // pattern lab's xip host if you have it configured, to be used with the QR code generator
 xipHostname = "http://patternlab.*.xip.io"

--- a/core/lib/PatternLab/Builder.php
+++ b/core/lib/PatternLab/Builder.php
@@ -184,6 +184,7 @@ class Builder {
 		$this->navItems['viewallpaths']      = json_encode($this->viewAllPaths);
 		$this->navItems['mqs']               = $this->gatherMQs();
 		$this->navItems['qrcodegeneratoron'] = $this->qrCodeGeneratorOn;
+		$this->navItems['qrcodegeneratorraw'] = $this->qrCodeGeneratorRaw;
 		$this->navItems['ipaddress']         = getHostByName(getHostName());
 		$this->navItems['xiphostname']       = $this->xipHostname;
 		$this->navItems['ishminimum']        = $this->ishMinimum;

--- a/core/styleguide/js/qrcode-generator.js
+++ b/core/styleguide/js/qrcode-generator.js
@@ -39,7 +39,7 @@ var qrCodeGenerator = {
 				var br                = document.createElement("br");
 				var a                 = document.createElement("a");
 				a.href                = qrCodeGenerator.createURL();
-				a.innerHTML           = "[link]"
+				a.innerHTML           = "[link]";
 				a.style.textTransform = "lowercase";
 				
 				var li                = document.createElement("li");
@@ -60,7 +60,7 @@ var qrCodeGenerator = {
 				
 				var a                 = document.createElement("a");
 				a.href                = "#";
-				a.innerHTML           = "the mini qr service is unavailable"
+				a.innerHTML           = "the mini qr service is unavailable";
 				a.style.textTransform = "lowercase";
 				
 				var li                = document.createElement("li");
@@ -86,7 +86,8 @@ var qrCodeGenerator = {
 	createURL: function() {
 		var path = window.location.pathname;
 		var search = window.location.search;
-		var url = (xipHostname != "") ? xipHostname.replace("*", ipAddress)+path+search : window.location.toString();
+		var patternUrl = (qrCodeGeneratorRaw) ? '/' + document.getElementById("sg-raw").getAttribute("href") : path+search;
+		var url = (xipHostname !== "") ? xipHostname.replace("*", ipAddress)+patternUrl : window.location.protocol + '//' + window.location.host + patternUrl;
 		return url;
 	}
 	

--- a/core/templates/partials/ipAddress.mustache
+++ b/core/templates/partials/ipAddress.mustache
@@ -2,6 +2,7 @@
   var ishMinimum           = {{ ishminimum }};
   var ishMaximum           = {{ ishmaximum }};
 	var qrCodeGeneratorOn    = {{ qrcodegeneratoron }};
+	var qrCodeGeneratorRaw   = {{ qrcodegeneratorraw }};
 	var ipAddress            = "{{ ipaddress }}";
 	var xipHostname          = "{{ xiphostname }}";
 </script>


### PR DESCRIPTION
This adds an option in config.ini to make the generated QR URL the raw URL of the pattern (i.e., the link you get when browsing to "Open in a new window" under the eye menu), rather than the default URL (iframe of the pattern within the styleguide).  This is more useful on our end since mobile browsers have trouble with the iframe and we're not testing multiple widths on phones anyway.

Thanks for a great dev tool.
