### PR TITLE
fix documentation links in the header bar

### DIFF
--- a/core/templates/partials/ishControls.mustache
+++ b/core/templates/partials/ishControls.mustache
@@ -53,8 +53,8 @@
 					<ul class="sg-acc-panel sg-right sg-checklist">
 						{{^ ishControlsHide.tools-follow }}<li><a href="#" id="navSyncButton" class="sg-checkbox sg-page-follow" data-state="off">Page Follow</a></li>{{/ ishControlsHide.tools-follow }}
 						{{^ ishControlsHide.tools-reload }}<li><a href="#" id="contentSyncButton" class="sg-checkbox sg-auto-reload" data-state="off">Auto-reload</a></li>{{/ ishControlsHide.tools-reload }}
-						{{^ ishControlsHide.tools-shortcuts }}<li><a href="http://pattern-lab.info/docs/advanced-keyboard-shortcuts.html" class="sg-icon-keyboard" target="_blank">Keyboard Shortcuts</a>{{/ ishControlsHide.tools-shortcuts }}
-						{{^ ishControlsHide.tools-docs }}<li><a href="http://pattern-lab.info/docs/" class="sg-icon-file" target="_blank">Pattern Lab Docs</a>{{/ ishControlsHide.tools-docs }}
+						{{^ ishControlsHide.tools-shortcuts }}<li><a href="http://patternlab.io/docs/advanced-keyboard-shortcuts.html" class="sg-icon-keyboard" target="_blank">Keyboard Shortcuts</a>{{/ ishControlsHide.tools-shortcuts }}
+						{{^ ishControlsHide.tools-docs }}<li><a href="http://patternlab.io/docs/" class="sg-icon-file" target="_blank">Pattern Lab Docs</a>{{/ ishControlsHide.tools-docs }}
 					</ul>
 				</li>
 				{{/ ishControlsHide.tools-all }}


### PR DESCRIPTION
links were pointing to pattern-lab.info, which is now just a Media Temple parking page -- changed to point to patternlab.io
